### PR TITLE
Exposing an ExportableInterface to allow classes other than collections to cascade exportable

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -19,6 +19,7 @@
 namespace Somnambulist\Collection;
 
 use function foo\func;
+use Somnambulist\Collection\Interfaces\ExportableInterface;
 use Somnambulist\Collection\Traits;
 use Somnambulist\Collection\Utils\Support;
 
@@ -29,7 +30,7 @@ use Somnambulist\Collection\Utils\Support;
  * @subpackage Somnambulist\Collection\Collection
  * @author     Dave Redfern
  */
-class Collection implements \ArrayAccess, \Countable, \IteratorAggregate, \Serializable
+class Collection implements \ArrayAccess, \Countable, \IteratorAggregate, \Serializable, ExportableInterface
 {
 
     use Traits\ArrayAccess;

--- a/src/Interfaces/ExportableInterface.php
+++ b/src/Interfaces/ExportableInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+namespace Somnambulist\Collection\Interfaces;
+
+/**
+ * Class ExportableInterface
+ *
+ * @package    Somnambulist\Collection\Interfaces
+ * @subpackage Somnambulist\Collection\Interfaces\ExportableInterface
+ */
+interface ExportableInterface
+{
+    /**
+     * Return an associative array of the stored data.
+     *
+     * @return array
+     */
+    public function toArray();
+}

--- a/src/Traits/Exportable.php
+++ b/src/Traits/Exportable.php
@@ -18,7 +18,7 @@
 
 namespace Somnambulist\Collection\Traits;
 
-use Somnambulist\Collection\Collection;
+use Somnambulist\Collection\Interfaces\ExportableInterface;
 
 /**
  * Class Exportable
@@ -41,7 +41,7 @@ trait Exportable
         $array = [];
 
         foreach ($this->items as $key => $value) {
-            if ($value instanceof Collection) {
+            if ($value instanceof ExportableInterface) {
                 $array[$key] = $value->toArray();
             } else {
                 $array[$key] = $value;

--- a/tests/Exportable/ExportableTest.php
+++ b/tests/Exportable/ExportableTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Somnambulist\Tests\Collection\Exportable;
+
+use PHPUnit\Framework\TestCase;
+use Somnambulist\Collection\Collection;
+use Somnambulist\Collection\Interfaces\ExportableInterface;
+use Somnambulist\Collection\Traits\Exportable;
+
+/**
+ * Class ExportableTest
+ *
+ * @package    Somnambulist\Tests\Collection\Exportable
+ * @subpackage Somnambulist\Tests\Collection\Exportable\ExportableTest
+ */
+class ExportableTest extends TestCase
+{
+
+    /**
+     * @group export
+     */
+    public function testToArrayOfCollections()
+    {
+        $col = new Collection([
+            'foo' => new Collection([1, 2, 3, 4]),
+            'bar' => new Collection([1, 2, 3, 4]),
+        ]);
+        $arr = $col->toArray();
+
+        $this->assertInternalType('array', $arr);
+        $this->assertEquals(['foo' => [1, 2, 3, 4], 'bar' => [1, 2, 3, 4]], $arr);
+    }
+
+    /**
+     * @group export
+     */
+    public function testToArrayOfClassImplementingExportable()
+    {
+        $item = new class implements ExportableInterface {
+
+            use Exportable;
+
+            public function toArray()
+            {
+                return ['key' => 'value'];
+            }
+        };
+
+        $this->assertEquals(['key' => 'value'], $item->toArray());
+    }
+
+    /**
+     * @group export
+     */
+    public function testToArrayOfCollectionsCascadesToArrayOfExportable()
+    {
+        $item = new class implements ExportableInterface {
+
+            use Exportable;
+
+            public function toArray()
+            {
+                return ['key' => 'value'];
+            }
+        };
+
+        $collection = new Collection([
+            'foo' => $item,
+            'bar' => new Collection(['item' => $item])
+        ]);
+
+        $this->assertEquals(['foo' => ['key' => 'value'], 'bar' => ['item' => ['key' => 'value']]], $collection->toArray());
+    }
+}


### PR DESCRIPTION
Makes library exactly 68% more awesome by allowing classes other than collection to have cascaded `toArray()`